### PR TITLE
Requirements Corrections

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,4 +1,3 @@
-python >= 3.9
 gtts
 pyttsx3
 edge-tts

--- a/requirements
+++ b/requirements
@@ -5,3 +5,4 @@ ffmpeg-python
 lxml
 python-docx
 python-pptx
+audio_metadata


### PR DESCRIPTION
When I went to install the requirements they always
gave errors

`python package not found version >= 3.9``

Even with the `.venv`` active I had these errors:

- `pip install -r requirements`
- `python -m pip install -r requirements`
- `python3.10 -m pip install -r requirements`

An alternative would be to use this for each package:

**`requirements`**
```
pyttsx3; python_version >= '3.9'
```

**Commits:**
- **fix: pip does not manage python versions**
- **chore: audio_metadata added in requirements**

