### PR TITLE
Adding required unit tests

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,4 +1,3 @@
-python >= 3.9
 gtts
 pyttsx3
 edge-tts

--- a/requirements
+++ b/requirements
@@ -5,3 +5,4 @@ ffmpeg-python
 lxml
 python-docx
 python-pptx
+audio_metadata

--- a/tests/test_txt2audio.py
+++ b/tests/test_txt2audio.py
@@ -1,0 +1,65 @@
+import sys, io
+
+from unittest import TestCase
+from unittest.mock import Mock, AsyncMock, patch
+from subprocess import call
+from pathlib import Path
+
+import txt2audio
+
+
+class TestTxt2Audio(TestCase):
+    def setUp(self):
+        Path('./hi.txt').write_text('hi')
+
+    def tearDown(self):
+        Path('./hi.txt').unlink(missing_ok=True)
+        Path('./hi.mp3').unlink(missing_ok=True)
+
+    @patch.object(txt2audio, 'BACK_END_TTS', 'PYTTS')
+    @patch.object(sys, 'argv', ['txt2audio.py', 'hi.txt'])
+    @patch('pyttsx3.init')
+    def test_audio_generate_mp3_pytts(self, mock_init):
+        mock_engine = mock_init()
+
+        txt2audio.main()
+
+        mp3 = str(Path('hi.mp3').resolve())
+
+        mock_engine.save_to_file.assert_called_with('hi', mp3)
+        mock_engine.runAndWait.assert_called()
+
+
+    @patch.object(txt2audio, 'BACK_END_TTS', 'EDGE_TTS')
+    @patch.object(sys, 'argv', ['txt2audio.py', 'hi.txt'])
+    def test_audio_generate_mp3_edge(self):
+        txt2audio.main()
+
+        self.assertTrue(
+            Path('hi.mp3').is_file()
+        )
+
+
+    @patch.object(sys, 'argv', ['txt2audio.py'])
+    @patch('builtins.exit')
+    def test_not_args(self, mock_exit):
+        stdout = io.StringIO()
+        sys.stdout = stdout
+
+        txt2audio.main()
+
+        sys.stdout = sys.__stdout__
+        stdout = stdout.getvalue().strip()
+
+        self.assertEqual(
+            stdout,
+            'Usage: txt2audio.py <input.txt>'
+        )
+
+        mock_exit.assert_called_with(1)
+
+
+    @patch.object(sys, 'argv', ['txt2audio.py', 'not_found.txt'])
+    def test_not_found_file_arg(self):
+        with self.assertRaises(FileNotFoundError):
+            txt2audio.main()

--- a/txt2audio.py
+++ b/txt2audio.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+
 import sys
 import os
 import logging
@@ -15,14 +16,23 @@ LANGUAGE_DICT = {"it-IT":"it"}
 LANGUAGE_DICT_PYTTS = {"it-IT":"italian", "en":"english"}
 VOICE = ""
 
+
 async def get_voices_edge_tts(lang=LANGUAGE_DICT["it-IT"]):
     vs = await edge_tts.VoicesManager.create()
     return vs.find(Gender="Female", Language=lang)
-async def generate_audio_edge_tts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> bool:
-    com = edge_tts.Communicate(text_in, VOICE)
+
+
+async def generate_audio_edge_tts(text_in:str, out_mp3_path:str, *, lang:str="it-IT", voice:str) -> bool:
+    com = edge_tts.Communicate(text_in, voice)
     await com.save(out_mp3_path)
     return True
+
+
 def generate_audio_pytts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> bool:
+    engine_ptts = pyttsx3.init()
+    #engine_ptts.setProperty('rate', 200)     # setting up new voice rate
+    engine_ptts.setProperty('volume',1.0)    # setting up volume level  between 0 and 1
+
     if engine_ptts.getProperty("voice") != lang:
         voices_property = engine_ptts.getProperty('voices')
         engine_ptts.setProperty("voice", voices_property[0].id)
@@ -30,32 +40,36 @@ def generate_audio_pytts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> 
     engine_ptts.runAndWait()
     return True
 
-if __name__ == "__main__":
+
+def main():
     if len(sys.argv) != 2:
         print(f"Usage: {sys.argv[0]} <input.txt>")
         exit(1)
+        return
+
     input_file_path=sys.argv[1]
     output_file_path=os.path.join(os.path.dirname(__file__), os.path.basename(input_file_path)[:-4]) + ".mp3"
     chapters = []
     metada_output = {}
     ch_metadatas = []
 
-    if BACK_END_TTS == "PYTTS":
-        engine_ptts = pyttsx3.init()
-        #engine_ptts.setProperty('rate', 200)     # setting up new voice rate
-        engine_ptts.setProperty('volume',1.0)    # setting up volume level  between 0 and 1
     text=""
     with open(sys.argv[1], "r", encoding="UTF-8") as file:
         text = ''.join(file.readlines())
+
     if BACK_END_TTS == "PYTTS":
         generate_audio_pytts(text, output_file_path, lang="en")
     else:
         loop = asyncio.get_event_loop_policy().get_event_loop()
         try:
             voices = loop.run_until_complete(get_voices_edge_tts(lang="it"))
-            VOICE = voices[0]["Name"]
-            loop.run_until_complete(generate_audio_edge_tts(text, output_file_path, lang="it-IT"))
+            voice = voices[0]["Name"]
+            loop.run_until_complete(generate_audio_edge_tts(text, output_file_path, lang="it-IT", voice=voice))
         finally:
             loop.close()
     #metadata_output = ffmetadata_generator.generate_ffmetadata(audio_paths)
     #generate_m4b(output_file_path, chapters, metada_output, chapter_metadata=ch_metadatas)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I had to adjust the txt2audio.py code to facilitate
the implementation of the tests, if necessary
I will revert the changes

To run the tests use:
`python -m unittest`

It refers to issue #5

- **test: adjusting code for tests**
- **test: txt2audio.py for audio generation and common errors**
