### PR TITLE
Pytts engine property

### DIFF
--- a/backend_audio/m4b.py
+++ b/backend_audio/m4b.py
@@ -12,7 +12,7 @@ import edge_tts
 import ffmpeg
 
 LANGUAGE_DICT = {"it-IT":"it"}
-LANGUAGE_DICT_PYTTS = {"it":"italian"}
+LANGUAGE_DICT_PYTTS = {"it":"italian", "en":"default"}
 voice_edge = "" #pylint: disable=C0103
 
 BIT_RATE_HUMAN = 40
@@ -81,7 +81,7 @@ def generate_audio_gtts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> b
         return __save_tts_audio_gtts(text_in, out_mp3_path, lang)
     return True
 
-def generate_audio_pytts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> bool:
+def generate_audio_pytts(text_in:str, out_mp3_path:str, *, lang:str="it") -> bool:
     """Generate audio using PYTTS apis"""
     if engine_ptts.getProperty("voice") != lang:
         engine_ptts.setProperty("voice", LANGUAGE_DICT_PYTTS[lang])
@@ -131,7 +131,7 @@ def init(backend:str):
         voice_edge = voices[0]["Name"]
 
 def generate_audio(text_in:str, out_mp3_path:str, *,
-                   lang:str="it-IT", backend="PYTTS") -> bool:
+                   lang:str="it", backend="PYTTS") -> bool:
     """Generating audio using tts apis"""
     ret_val = True
     text_in = text_in.strip()

--- a/backend_audio/m4b.py
+++ b/backend_audio/m4b.py
@@ -83,8 +83,8 @@ def generate_audio_gtts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> b
 
 def generate_audio_pytts(text_in:str, out_mp3_path:str, *, lang:str="it-IT") -> bool:
     """Generate audio using PYTTS apis"""
-    if engine_ptts.getProperty("voice_edge") != lang:
-        engine_ptts.setProperty("voice_edge", LANGUAGE_DICT_PYTTS[lang])
+    if engine_ptts.getProperty("voice") != lang:
+        engine_ptts.setProperty("voice", LANGUAGE_DICT_PYTTS[lang])
     engine_ptts.save_to_file(text_in, out_mp3_path)
     engine_ptts.runAndWait()
     return True

--- a/docx2audio.py
+++ b/docx2audio.py
@@ -22,8 +22,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-if sys.platform in ('win32', 'cygwin'):
+if sys.platform in ("win32", "cygwin"):
     BACK_END_TTS = "EDGE_TTS"
+elif sys.platform == "darwin":
+    BACK_END_TTS = '"GTTS'
 else:
     BACK_END_TTS = "PYTTS"
 

--- a/docx2audio.py
+++ b/docx2audio.py
@@ -5,6 +5,7 @@ description: Convert your docx to audiobook in M4B format
 Usage example:
     python docx2audio.py document.docx
 """
+import sys
 import os
 import logging
 from typing import List, Tuple, Union
@@ -21,7 +22,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-BACK_END_TTS = "EDGE_TTS"
+if sys.platform in ('win32', 'cygwin'):
+    BACK_END_TTS = "EDGE_TTS"
+else:
+    BACK_END_TTS = "PYTTS"
 
 TITLE_KEYWORD  = {"it-IT":"TITOLO",   "en":"TITLE"}
 CHAPTER_KEYWORD= {"it-IT":"CAPITOLO", "en":"CHAPTER"}

--- a/ebook2audio.py
+++ b/ebook2audio.py
@@ -20,8 +20,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-if sys.platform in ('win32', 'cygwin'):
+if sys.platform in ("win32", "cygwin"):
     BACK_END_TTS = "EDGE_TTS"
+elif sys.platform == "darwin":
+    BACK_END_TTS = '"GTTS'
 else:
     BACK_END_TTS = "PYTTS"
 

--- a/ebook2audio.py
+++ b/ebook2audio.py
@@ -5,6 +5,7 @@ description: starting from epub file generate a m4b file
 Usage example:
     python ebook2audio.py book.epub
 """
+import sys
 import zipfile
 import tempfile
 import os
@@ -19,7 +20,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-BACK_END_TTS = "EDGE_TTS"
+if sys.platform in ('win32', 'cygwin'):
+    BACK_END_TTS = "EDGE_TTS"
+else:
+    BACK_END_TTS = "PYTTS"
 
 def extract_by_epub(epub_path:str, directory_to_extract_path:str) -> None:
     """Unzip the epub file and extract all in a temp directory"""

--- a/pptx2audio.py
+++ b/pptx2audio.py
@@ -24,7 +24,7 @@ elif sys.platform == "darwin":
 else:
     BACK_END_TTS = "PYTTS"
 LANGUAGE_DICT = {"it-IT":"it"}
-LANGUAGE_DICT_PYTTS = {"it-IT":"italian", "en":"english"}
+LANGUAGE_DICT_PYTTS = {"it":"italian", "en":"english"}
 
 def __get_notes(note: slide.NotesSlide) -> str:
     print(note)

--- a/pptx2audio.py
+++ b/pptx2audio.py
@@ -17,8 +17,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
-if sys.platform in ('win32', 'cygwin'):
+if sys.platform in ("win32", "cygwin"):
     BACK_END_TTS = "EDGE_TTS"
+elif sys.platform == "darwin":
+    BACK_END_TTS = '"GTTS'
 else:
     BACK_END_TTS = "PYTTS"
 LANGUAGE_DICT = {"it-IT":"it"}

--- a/pptx2audio.py
+++ b/pptx2audio.py
@@ -5,6 +5,7 @@ description: Convert your pptx to audiobook in M4B format
 Usage example:
     python pptx2audio.py presentation.pptx
 """
+import sys
 import os
 import logging
 import asyncio
@@ -16,7 +17,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
-BACK_END_TTS = "EDGE_TTS"
+if sys.platform in ('win32', 'cygwin'):
+    BACK_END_TTS = "EDGE_TTS"
+else:
+    BACK_END_TTS = "PYTTS"
 LANGUAGE_DICT = {"it-IT":"it"}
 LANGUAGE_DICT_PYTTS = {"it-IT":"italian", "en":"english"}
 

--- a/txt2audio.py
+++ b/txt2audio.py
@@ -15,7 +15,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
-BACK_END_TTS = "EDGE_TTS" #"PYTTS"
+if sys.platform in ('win32', 'cygwin'):
+    BACK_END_TTS = "EDGE_TTS"
+else:
+    BACK_END_TTS = "PYTTS"
 LANGUAGE = "it"
 
 def main():

--- a/txt2audio.py
+++ b/txt2audio.py
@@ -15,8 +15,10 @@ from frontend import input_tool
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
-if sys.platform in ('win32', 'cygwin'):
+if sys.platform in ("win32", "cygwin"):
     BACK_END_TTS = "EDGE_TTS"
+elif sys.platform == "darwin":
+    BACK_END_TTS = '"GTTS'
 else:
     BACK_END_TTS = "PYTTS"
 LANGUAGE = "it"


### PR DESCRIPTION
I wasn't able to run the script on my WSL environment. To write the user guide on the docs page, I needed to make some adjustments to make it run on linux & MacOS.

I made the BACK_END_TTS variable dependent on the system's operating system.

I also made some updates to the language dictionary keys to make them compatible with pyttsx3. The documentation for pyttsx3 also doesn't have `voice_edge` as a valid property of the engine; I updated to `voice`.

[pyttsx3 documentation reference](https://pyttsx3.readthedocs.io/en/latest/engine.html#pyttsx3.engine.Engine.getProperty)